### PR TITLE
Save omega-prm-v2 results to a single file

### DIFF
--- a/data/omegaPRM_v2/run_omegaprm.py
+++ b/data/omegaPRM_v2/run_omegaprm.py
@@ -8,6 +8,8 @@ from omegaprm import LanguageModel, OmegaPRM
 
 DS_NAME = "math-aps-v2"
 
+logger: logging.Logger
+
 
 # Set up logging based on provided log file prefix
 def setup_logging(log_file_prefix: str):

--- a/data/omegaPRM_v2/run_omegaprm.py
+++ b/data/omegaPRM_v2/run_omegaprm.py
@@ -68,9 +68,11 @@ def process_question(omega_prm: OmegaPRM, question: Dict[str, str]):
 
 # Save collected data for each question
 def save_question_data(collected_data: Dict, index: int, output_path: str):
-    with open(output_path, 'w') as f:
-        json.dump(collected_data, f, indent=4)
-    logger.info(f"Saved processed data to {output_path}")
+    collected_data["question_id"] = index
+    with open(output_path, "a") as fd:
+        line = json.dumps(collected_data)
+        fd.write(f"{line}\n")
+    logger.info(f"Question {index} is saved to {output_path}")
 
 
 def main(args):

--- a/data/omegaPRM_v2/run_omegaprm.py
+++ b/data/omegaPRM_v2/run_omegaprm.py
@@ -79,6 +79,9 @@ def main(args):
 
     os.makedirs(args.output_dir, exist_ok=True)
     output_file = os.path.join(args.output_dir, f"{DS_NAME}.jsonl")
+    # ensure output_file is empty since we are appending to it later
+    with open(output_file, "w") as fd:
+        fd.write("")
 
     logger.info("Starting OmegaPRM processing")
     logger.info(f"Using model: {args.model_name} on device: {args.device}")

--- a/data/omegaPRM_v2/run_omegaprm.py
+++ b/data/omegaPRM_v2/run_omegaprm.py
@@ -67,21 +67,22 @@ def process_question(omega_prm: OmegaPRM, question: Dict[str, str]):
 
 
 # Save collected data for each question
-def save_question_data(collected_data: Dict, index: int, output_dir: str):
-    os.makedirs(output_dir, exist_ok=True)  # Ensure the output directory exists
-    filename = os.path.join(output_dir, f"question_{index}.json")
-    with open(filename, 'w') as f:
+def save_question_data(collected_data: Dict, index: int, output_path: str):
+    with open(output_path, 'w') as f:
         json.dump(collected_data, f, indent=4)
-    logger.info(f"Saved processed data to {filename}")
+    logger.info(f"Saved processed data to {output_path}")
 
 
 def main(args):
     global logger
     logger = setup_logging(args.log_file_prefix)
 
+    os.makedirs(args.output_dir, exist_ok=True)
+    output_file = os.path.join(args.output_dir, f"{DS_NAME}.jsonl")
+
     logger.info("Starting OmegaPRM processing")
     logger.info(f"Using model: {args.model_name} on device: {args.device}")
-    logger.info(f"Output directory: {args.output_dir}")
+    logger.info(f"Output file: {output_file}")
     logger.info(f"Question file: {args.question_file}")
 
     questions = load_questions(args.question_file)
@@ -113,7 +114,7 @@ def main(args):
     for idx, question in enumerate(questions):
         if should_process_question(question, llm):
             collected_data = process_question(omega_prm, question)
-            save_question_data(collected_data, idx, args.output_dir)
+            save_question_data(collected_data, idx, output_file)
             processed_count += 1
         else:
             logger.info(f"Skipping question: {question['problem']}")

--- a/data/omegaPRM_v2/run_omegaprm.py
+++ b/data/omegaPRM_v2/run_omegaprm.py
@@ -6,6 +6,8 @@ from omegaprm import OmegaPRM, LanguageModel
 from tqdm import tqdm
 from typing import Dict
 
+DS_NAME = "math-aps-v2"
+
 
 # Set up logging based on provided log file prefix
 def setup_logging(log_file_prefix: str):
@@ -124,7 +126,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run OmegaPRM on filtered questions")
 
     parser.add_argument("--question_file", type=str, required=True, help="Path to the questions JSON file")
-    parser.add_argument("--output_dir", type=str, default="output", help="Directory to save output JSON files")
+    parser.add_argument("--output_dir", type=str, default="output", help=f"Directory to save the output file {DS_NAME}.jsonl")
     parser.add_argument("--log_file_prefix", type=str, default="omega_prm", help="Prefix for the log files")
     parser.add_argument("--model_name", type=str, default="/root/.cache/modelscope/hub/Qwen/Qwen2___5-Math-7B-Instruct",
                         help="Model name or path for the language model")


### PR DESCRIPTION
For now OmegaPRM-v2 saves each QA to separate JSON files e.g. "question_{index}.json". It should save these results to a single file for better management and later preprocessing.

In case of accidental interruption in the midst of generation, results should be saved every time a QA is done. So we will append to a .jsonl file whose lines are separate JSON data objects, originally saved in separate JSON files.